### PR TITLE
Document instructions for running tests locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,3 +408,13 @@ Logger.root.onRecord.listen((LogRecord record) {
 ```
 
 Set the log level according your needs. Most times, `INFO` is what you want. `ALL` is good for filling issues.
+
+## Development
+Dependencies of this packages can installed with `pub get` and test cases can
+be run with `pub run test`. These test cases requires a redis running on
+`localhost:6379`, for local development this can be created with docker:
+
+ * `docker run --rm -p 6379:6379 redis`
+
+This starts a container running redis and exposes port `6379` localhost, when
+killed using `ctrl+c` the container will be deleted.

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Logger.root.onRecord.listen((LogRecord record) {
 
 Set the log level according your needs. Most times, `INFO` is what you want. `ALL` is good for filling issues.
 
-## Development
+## Testing
 Dependencies of this packages can installed with `pub get` and test cases can
 be run with `pub run test`. These test cases requires a redis running on
 `localhost:6379`, for local development this can be created with docker:


### PR DESCRIPTION
Just a neat hint so I don't forget... :)

If we had a quick way of testing if it's possible to connect to a port on localhost, we could even make the tests skip if you are not running a redis server on localhost... and print a nice warning.