### PR TITLE
Error propagation

### DIFF
--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -274,7 +274,23 @@ class _ClientDispatcher extends ReplyDispatcher {
     if (_transaction.inProgress) {
       _transaction.onErrorReply(command, reply, codec);
     } else {
-      command.completeError(reply, codec);
+      command.completeErrorReply(reply, codec);
+    }
+  }
+
+  @override
+  void onError(Object e, [StackTrace stackStrace]) {
+    try {
+      for (var command in _unreplied) {
+        command.completeError(e, stackStrace);
+      }
+      _unreplied.clear();
+      if (_transaction.inProgress) {
+        _transaction.onError(e, stackStrace);
+      }
+    } finally {
+      // Disconnect to ensure the socket is destroyed.
+      disconnect();
     }
   }
 

--- a/lib/src/client/connection.dart
+++ b/lib/src/client/connection.dart
@@ -58,9 +58,14 @@ class Connection {
 
   /// Closes the socket.
   Future<void> disconnect() async {
-    await _socket.flush();
-    await _socket.close();
-    _socket.destroy();
+    try {
+      await _socket.flush();
+      await _socket.close();
+    } finally {
+      // Always destroy the socket to avoid leaking. Just in case there is an
+      // error during flush for some reason.
+      _socket.destroy();
+    }
 
     log.info('Disconnected.');
   }

--- a/lib/src/client/dispatcher.dart
+++ b/lib/src/client/dispatcher.dart
@@ -21,7 +21,7 @@ abstract class DispatcherBase {
 
   /// Creates a [DispatcherBase] with the given connection.
   DispatcherBase(this._connection) {
-    _connection.listen(onData, onDone);
+    _connection.listen(onData, onError, onDone);
   }
 
   /// Sends [data] through the network connection.
@@ -34,6 +34,13 @@ abstract class DispatcherBase {
 
   /// Overwrite this method for receiving incoming [data].
   void onData(List<int> data);
+
+  /// Overwrite this method to handle errors that occured reading or writing
+  /// to the connection.
+  void onError(Object e, [StackTrace stackStrace]) {
+    // Default to rethrow the error
+    throw e; // ignore: only_throw_errors
+  }
 
   /// Overwrite this method for receiving on done signal.
   void onDone();

--- a/lib/src/client/monitor.dart
+++ b/lib/src/client/monitor.dart
@@ -81,6 +81,11 @@ class _MonitorDispatcher extends DispatcherBase {
   }
 
   @override
+  void onError(Object e, [StackTrace st]) {
+    _controller.addError(e, st);
+  }
+
+  @override
   void onDone() {
     _controller.close();
   }

--- a/lib/src/client/pubsub.dart
+++ b/lib/src/client/pubsub.dart
@@ -220,6 +220,11 @@ class _PubSubDispatcher<K, V> extends ReplyDispatcher {
   }
 
   @override
+  void onError(Object e, [StackTrace st]) {
+    _controller.addError(e, st);
+  }
+
+  @override
   void onDone() {
     _controller.close();
   }

--- a/lib/src/client/terminal.dart
+++ b/lib/src/client/terminal.dart
@@ -75,6 +75,11 @@ class _TerminalDispatcher extends DispatcherBase {
   }
 
   @override
+  void onError(Object e, [StackTrace st]) {
+    _controller.addError(e, st);
+  }
+
+  @override
   void onDone() {
     _controller.close();
   }

--- a/lib/src/client/transaction.dart
+++ b/lib/src/client/transaction.dart
@@ -52,7 +52,18 @@ class Transaction {
       _abort(reply, codec);
     }
 
-    command.completeError(reply, codec);
+    command.completeErrorReply(reply, codec);
+  }
+
+  /// Completes all commands in the transaction with [error].
+  void onError(Object error, StackTrace st) {
+    assert(_inProgress);
+
+    for (final command in _queued) {
+      command.completeError(error);
+    }
+
+    end();
   }
 
   /// Completes all the queued commands.
@@ -71,7 +82,7 @@ class Transaction {
     final error = ErrorReply('Transaction discarded.'.codeUnits);
 
     for (final command in _queued) {
-      command.completeError(error, codec);
+      command.completeErrorReply(error, codec);
     }
 
     command.complete(reply, codec);
@@ -82,7 +93,7 @@ class Transaction {
   /// Completes all the queued commands with the given error [reply].
   void _abort(ErrorReply reply, RedisCodec codec) {
     for (final command in _queued) {
-      command.completeError(reply, codec);
+      command.completeErrorReply(reply, codec);
     }
 
     end();
@@ -129,7 +140,7 @@ class Transaction {
       final reply = array[i];
 
       if (reply is ErrorReply) {
-        command.completeError(reply, codec);
+        command.completeErrorReply(reply, codec);
       } else {
         command.complete(reply, codec);
       }

--- a/lib/src/command/command.dart
+++ b/lib/src/command/command.dart
@@ -30,7 +30,10 @@ abstract class Command<T> {
   void complete(Reply reply, RedisCodec codec);
 
   /// Completes this command with the given error [reply].
-  void completeError(ErrorReply reply, RedisCodec codec);
+  void completeErrorReply(ErrorReply reply, RedisCodec codec);
+
+  /// Completes this command with an error, typically due to socket errors.
+  void completeError(Object e, [StackTrace st]);
 }
 
 /// Base class for implementing commands.
@@ -65,11 +68,15 @@ class CommandBase<T> implements Command<T> {
   }
 
   @override
-  void completeError(ErrorReply reply, RedisCodec codec) {
+  void completeErrorReply(ErrorReply reply, RedisCodec codec) {
     final value = codec.decode<String>(reply);
 
     _completer.completeError(RedisException(value));
   }
+
+  @override
+  void completeError(Object e, [StackTrace st]) =>
+      _completer.completeError(e, st);
 
   /// Completes this command with the value in the given [reply].
   T _complete(Reply reply, RedisCodec codec) {

--- a/lib/src/exception.dart
+++ b/lib/src/exception.dart
@@ -12,3 +12,11 @@ class RedisException implements Exception {
   @override
   String toString() => 'RedisException: $message';
 }
+
+/// Exception thrown if there was an attempt to send a command after the
+/// connection was closed.
+class RedisConnectionClosedException extends RedisException {
+  /// Creates a [RedisConnectionClosedException] instance.
+  const RedisConnectionClosedException()
+      : super('attempted to send data after connection was closed');
+}

--- a/test/command/command_test.dart
+++ b/test/command/command_test.dart
@@ -69,7 +69,7 @@ void main() {
         final command = Command<String>(<Object>['CMD']);
 
         final reply = ErrorReply('ERR'.codeUnits);
-        command.completeError(reply, codec);
+        command.completeErrorReply(reply, codec);
 
         expect(command.future, throwsA(const TypeMatcher<RedisException>()));
       });

--- a/test/redisproxy.dart
+++ b/test/redisproxy.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+import 'dart:io';
+
+void _ignoreErr(Object error) {}
+
+/// Simple proxy that forwards bytes to redis server on localhost and supports
+/// breaking the connections.
+class RedisProxy {
+  final ServerSocket _server;
+  final Completer _done = Completer<void>();
+
+  RedisProxy(this._server) {
+    _server.forEach(_handle);
+  }
+
+  void _handle(Socket client) async {
+    final redis = await Socket.connect(InternetAddress.loopbackIPv4, 6379);
+    // Set TCP no delay
+    client.setOption(SocketOption.tcpNoDelay, true);
+    redis.setOption(SocketOption.tcpNoDelay, true);
+    // Pipe until, _done then we break the connection
+    try {
+      await Future.any<void>([
+        client.pipe(redis).catchError(_ignoreErr),
+        redis.pipe(client).catchError(_ignoreErr),
+        _done.future,
+      ]);
+    } finally {
+      client.destroy();
+      redis.destroy();
+    }
+  }
+
+  /// Close server and connections
+  Future closeConnectionsAndServer() async {
+    _done.complete();
+    await _server.close();
+  }
+
+  String get connectionString =>
+      'redis://${_server.address.address}:${_server.port}';
+
+  static Future<RedisProxy> create() async {
+    final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    return RedisProxy(server);
+  }
+}


### PR DESCRIPTION
With all pending and future commands following a broken connection will cause an exception.

We also added a `Connection.done` future, that will be resolved with an error if the connection isn't closed gracefully, thus, people who previously relied on connection breakages propagating to the root Zone and causing a process crash will still get this behavior.

Indeed crashing the process on a broken connection a crude, but very effective reconnect strategy. In fact I think it's fine to suggest that most people just use this.. And let people who really want to do reconnect strategies use `Connection` directly, rather than using `Client.connect(...)` which currently doesn't allow you to access `Connection.done`.

This is aimed at fixing #8, it might be nice to provide a client wrapper that can do reconnect, but this is a good first step.